### PR TITLE
fix: missing variable declaration in records.tf

### DIFF
--- a/root/examples/terragrunt.hcl
+++ b/root/examples/terragrunt.hcl
@@ -53,4 +53,15 @@ inputs = {
     },
     local.custom_tags
   )
+
+  records = {
+    "myrecord" = {
+      name = "test"
+      type = "A"
+      ttl  = 300
+      records = [
+        "8.8.8.8"
+      ]
+    }
+  }
 }

--- a/root/variables.tf
+++ b/root/variables.tf
@@ -19,3 +19,9 @@ variable "custom_tags" {
   type    = map
   default = {}
 }
+
+variable "records" {
+  type        = map
+  default     = {}
+  description = "Map or records to add to the dns zone"
+}

--- a/root/variables.tf
+++ b/root/variables.tf
@@ -23,5 +23,5 @@ variable "custom_tags" {
 variable "records" {
   type        = map
   default     = {}
-  description = "Map or records to add to the dns zone"
+  description = "Map of records to add to the dns zone"
 }

--- a/subdomain/examples/terragrunt.hcl
+++ b/subdomain/examples/terragrunt.hcl
@@ -30,4 +30,15 @@ inputs = {
     },
     local.custom_tags
   )
+
+  records = {
+    "myrecord" = {
+      name = "test"
+      type = "A"
+      ttl  = 300
+      records = [
+        "8.8.8.8"
+      ]
+    }
+  }
 }

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -23,5 +23,5 @@ variable "records" {
 variable "records" {
   type        = map
   default     = {}
-  description = "Map or records to add to the dns zone"
+  description = "Map of records to add to the dns zone"
 }

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -19,3 +19,9 @@ variable "records" {
   type    = any
   default = {}
 }
+
+variable "records" {
+  type        = map
+  default     = {}
+  description = "Map or records to add to the dns zone"
+}


### PR DESCRIPTION
fix this:
> Error: Reference to undeclared input variable
>  on records.tf line 2, in resource "aws_route53_record" "records":
>  2:   for_each = var.records
>
>An input variable with the name "records" has not been declared. This variable
>can be declared with a variable "records" {} block.

Also added terragrunt.hcl example file.