### PR TITLE
feat: Add terraform validate to travis build & fix duplicate variable declaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+.idea
+.secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     terraform version
 
 script:
-  - terraform fmt -check -diff
+  - bash scripts/tf_checks.sh
 
 after_success:
   - semantic-release -ghr -vf --travis-com

--- a/root/examples/terragrunt.hcl
+++ b/root/examples/terragrunt.hcl
@@ -53,4 +53,15 @@ inputs = {
     },
     local.custom_tags
   )
+
+  records = {
+    "myrecord" = {
+      name = "test"
+      type = "A"
+      ttl  = 300
+      records = [
+        "8.8.8.8"
+      ]
+    }
+  }
 }

--- a/root/variables.tf
+++ b/root/variables.tf
@@ -19,3 +19,9 @@ variable "custom_tags" {
   type    = map
   default = {}
 }
+
+variable "records" {
+  type        = map
+  default     = {}
+  description = "Map or records to add to the dns zone"
+}

--- a/root/variables.tf
+++ b/root/variables.tf
@@ -23,5 +23,5 @@ variable "custom_tags" {
 variable "records" {
   type        = map
   default     = {}
-  description = "Map or records to add to the dns zone"
+  description = "Map of records to add to the dns zone"
 }

--- a/scripts/tf_checks.sh
+++ b/scripts/tf_checks.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+#
+find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read -r dir; do 
+    terraform init -backend=false "$dir" || exit 1 
+    terraform validate "$dir" || exit 1 
+    terraform fmt -check -diff "$dir" && echo "Directory $(basename $dir) [√]" || exit 1
+done

--- a/scripts/tf_checks.sh
+++ b/scripts/tf_checks.sh
@@ -3,5 +3,5 @@
 find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read -r dir; do 
     terraform init -backend=false "$dir" || exit 1 
     terraform validate "$dir" || exit 1 
-    terraform fmt -check -diff "$dir" && echo "Directory $(basename $dir) [√]" || exit 1
+    terraform fmt -check -diff "$dir" && echo "[√] $(basename $dir)" || exit 1
 done

--- a/subdomain/examples/terragrunt.hcl
+++ b/subdomain/examples/terragrunt.hcl
@@ -30,4 +30,15 @@ inputs = {
     },
     local.custom_tags
   )
+
+  records = {
+    "myrecord" = {
+      name = "test"
+      type = "A"
+      ttl  = 300
+      records = [
+        "8.8.8.8"
+      ]
+    }
+  }
 }

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -23,5 +23,5 @@ variable "records" {
 variable "records" {
   type        = map
   default     = {}
-  description = "Map or records to add to the dns zone"
+  description = "Map of records to add to the dns zone"
 }

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -16,11 +16,6 @@ variable "custom_tags" {
 }
 
 variable "records" {
-  type    = any
-  default = {}
-}
-
-variable "records" {
   type        = map
   default     = {}
   description = "Map of records to add to the dns zone"

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -19,3 +19,9 @@ variable "records" {
   type    = any
   default = {}
 }
+
+variable "records" {
+  type        = map
+  default     = {}
+  description = "Map or records to add to the dns zone"
+}

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -20,3 +20,9 @@ variable "records" {
   default     = {}
   description = "Map of records to add to the dns zone"
 }
+
+variable "records" {
+  type        = map
+  default     = {}
+  description = "Map of records to add to the dns zone"
+}

--- a/subdomain/variables.tf
+++ b/subdomain/variables.tf
@@ -20,9 +20,3 @@ variable "records" {
   default     = {}
   description = "Map of records to add to the dns zone"
 }
-
-variable "records" {
-  type        = map
-  default     = {}
-  description = "Map of records to add to the dns zone"
-}


### PR DESCRIPTION
I fix a duplicate variable but I also notice that terraform fmt does not run in subdirectory. Only in current directory.
If you have not terraform file in the root directory then the command `terraform fmt`will always success. 
I took the opportunity to improve the travis build so it can also run `terraform validate` inside subdirectory. This will have trigger an error. 